### PR TITLE
Feature/nav graph onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 *.aab
+/.idea/inspectionProfiles/Project_Default.xml

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/RootComponent.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/RootComponent.kt
@@ -40,7 +40,6 @@ fun RootComponent(moveToBackCallBack: OnBackPressedCallback) {
             },
             bottomBar = {
                 BottomNav(
-                    navController = navController,
                     bottomBarState = bottomBarState.value,
                     onClickNext = { Screen.nextScreen(navController) },
                     onClickBack = { Screen.onBackPressed(moveToBackCallBack, navController) },

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/RootComponent.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/RootComponent.kt
@@ -1,6 +1,5 @@
 package com.antisnusbolaget.slutasnusa2
 
-
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -20,14 +19,12 @@ import com.antisnusbolaget.slutasnusa2.navigation.BottomBarVisibility
 import com.antisnusbolaget.slutasnusa2.navigation.BottomNav
 import com.antisnusbolaget.slutasnusa2.navigation.NavGraph
 import com.antisnusbolaget.slutasnusa2.navigation.Screen
-import com.antisnusbolaget.slutasnusa2.navigation.Screen.Companion.nextScreen
-import com.antisnusbolaget.slutasnusa2.navigation.Screen.Companion.onBackPressed
 import com.antisnusbolaget.slutasnusa2.ui.components.TopBar
 
 @Composable
 fun RootComponent(moveToBackCallBack: OnBackPressedCallback) {
     val navController = rememberNavController()
-    val bottomBarState = remember { mutableStateOf(BottomBarVisibility(shouldShowNav = false, shouldShowYellow = false)) }
+    val bottomBarState = remember { mutableStateOf(BottomBarVisibility(isHomeScreen = false, isOnBoarding = false)) }
     val topBarState = rememberSaveable { mutableStateOf(false) }
     val navBackStackEntry by navController.currentBackStackEntryAsState()
 
@@ -45,8 +42,8 @@ fun RootComponent(moveToBackCallBack: OnBackPressedCallback) {
                 BottomNav(
                     navController = navController,
                     bottomBarState = bottomBarState.value,
-                    onClickNext = { navController.navigate(nextScreen()) },
-                    onClickBack = { onBackPressed(moveToBackCallBack) },
+                    onClickNext = { navController.navigate(Screen.nextScreen()) },
+                    onClickBack = { Screen.onBackPressed(moveToBackCallBack) },
                 )
             },
             topBar = { TopBar(showTopBar = topBarState.value) },

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/RootComponent.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/RootComponent.kt
@@ -42,8 +42,8 @@ fun RootComponent(moveToBackCallBack: OnBackPressedCallback) {
                 BottomNav(
                     navController = navController,
                     bottomBarState = bottomBarState.value,
-                    onClickNext = { navController.navigate(Screen.nextScreen()) },
-                    onClickBack = { Screen.onBackPressed(moveToBackCallBack) },
+                    onClickNext = { Screen.nextScreen(navController) },
+                    onClickBack = { Screen.onBackPressed(moveToBackCallBack, navController) },
                 )
             },
             topBar = { TopBar(showTopBar = topBarState.value) },

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/BottomNav.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/BottomNav.kt
@@ -10,12 +10,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import com.antisnusbolaget.slutasnusa2.ui.components.BottomNavOnBoarding
 
 @Composable
 fun BottomNav(
-    navController: NavController,
     bottomBarState: BottomBarVisibility,
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
@@ -39,7 +37,6 @@ fun BottomNav(
                 BottomNavOnBoarding(
                     onClickNext = onClickNext,
                     onClickBack = onClickBack,
-                    navController = navController,
                 )
             }
     }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/BottomNav.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/BottomNav.kt
@@ -5,13 +5,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.antisnusbolaget.slutasnusa2.ui.components.BottomScaffoldYellow
+import com.antisnusbolaget.slutasnusa2.ui.components.BottomNavOnBoarding
 
 @Composable
 fun BottomNav(
@@ -21,7 +21,7 @@ fun BottomNav(
     onClickBack: () -> Unit,
 ) {
     when (bottomBarState) {
-        BottomBarVisibility(shouldShowNav = true, shouldShowYellow = false) ->
+        BottomBarVisibility(isHomeScreen = true, isOnBoarding = false) ->
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -29,14 +29,14 @@ fun BottomNav(
             ) {
                 Text(text = "navBar")
             }
-        BottomBarVisibility(shouldShowNav = false, shouldShowYellow = true) ->
+        BottomBarVisibility(isHomeScreen = false, isOnBoarding = true) ->
             Box(
                 modifier = Modifier
                     .wrapContentWidth()
                     .background(MaterialTheme.colorScheme.background)
                     .height(60.dp),
             ) {
-                BottomScaffoldYellow(
+                BottomNavOnBoarding(
                     onClickNext = onClickNext,
                     onClickBack = onClickBack,
                     navController = navController,

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/NavGraph.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/NavGraph.kt
@@ -10,9 +10,11 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.antisnusbolaget.slutasnusa2.ui.screens.AchievementScreen
 import com.antisnusbolaget.slutasnusa2.ui.screens.CostScreen
 import com.antisnusbolaget.slutasnusa2.ui.screens.DateScreen
 import com.antisnusbolaget.slutasnusa2.ui.screens.HomeScreen
+import com.antisnusbolaget.slutasnusa2.ui.screens.SettingScreen
 import com.antisnusbolaget.slutasnusa2.ui.screens.UnitScreen
 import com.antisnusbolaget.slutasnusa2.viewmodel.OnBoardingViewModel
 import org.koin.androidx.compose.koinViewModel
@@ -51,10 +53,17 @@ fun NavGraph(navController: NavHostController) {
             composable(Screen.Home.route) {
                 HomeScreen()
             }
+            composable(Screen.Settings.route) {
+                SettingScreen()
+            }
+            composable(Screen.Achievement.route) {
+                AchievementScreen()
+            }
         }
     }
 }
 
+// Scope viewModel to graph, as soon as graph is popped -> viewModel with be cleared
 @Composable
 inline fun <reified T : ViewModel> NavBackStackEntry.sharedViewModel(navController: NavController): T {
     val navGraphRoute = destination.parent?.route ?: return koinViewModel()

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/NavGraph.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/NavGraph.kt
@@ -1,22 +1,65 @@
 package com.antisnusbolaget.slutasnusa2.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navigation
 import com.antisnusbolaget.slutasnusa2.ui.screens.CostScreen
 import com.antisnusbolaget.slutasnusa2.ui.screens.DateScreen
 import com.antisnusbolaget.slutasnusa2.ui.screens.HomeScreen
 import com.antisnusbolaget.slutasnusa2.ui.screens.UnitScreen
+import com.antisnusbolaget.slutasnusa2.viewmodel.OnBoardingViewModel
+import org.koin.androidx.compose.koinViewModel
 
-const val ON_BOARDING_GRAPH_ROUTE = "onboarding_route"
+const val ON_BOARDING_GRAPH_ROUTE = "on_boarding_route"
+const val HOME_ROUTE = "home_route"
 
 @Composable
 fun NavGraph(navController: NavHostController) {
-    NavHost(navController = navController, startDestination = Screen.Cost.route, route = ON_BOARDING_GRAPH_ROUTE) {
-        composable(Screen.Home.route) { HomeScreen() }
-        composable(Screen.Cost.route) { CostScreen() }
-        composable(Screen.Unit.route) { UnitScreen() }
-        composable(Screen.Date.route) { DateScreen() }
+    NavHost(
+        navController = navController,
+        startDestination = ON_BOARDING_GRAPH_ROUTE,
+    ) {
+        navigation(
+            startDestination = Screen.Cost.route,
+            route = ON_BOARDING_GRAPH_ROUTE,
+        ) {
+            composable(Screen.Cost.route) {
+                val viewModel = it.sharedViewModel<OnBoardingViewModel>(navController)
+                CostScreen()
+            }
+            composable(Screen.Unit.route) {
+                val viewModel = it.sharedViewModel<OnBoardingViewModel>(navController)
+                UnitScreen()
+            }
+            composable(Screen.Date.route) {
+                val viewModel = it.sharedViewModel<OnBoardingViewModel>(navController)
+                DateScreen()
+            }
+        }
+
+        navigation(
+            startDestination = Screen.Home.route,
+            route = HOME_ROUTE,
+        ) {
+            composable(Screen.Home.route) {
+                HomeScreen()
+            }
+        }
     }
+}
+
+@Composable
+inline fun <reified T : ViewModel> NavBackStackEntry.sharedViewModel(navController: NavController): T {
+    val navGraphRoute = destination.parent?.route ?: return koinViewModel()
+    val parentEntry = remember(this) {
+        navController.getBackStackEntry(navGraphRoute)
+    }
+    return viewModel(parentEntry)
 }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
@@ -15,10 +15,10 @@ sealed class Screen(val route: String, var title: String) {
 
     companion object {
 
-        private val onBoardingScreensIndex = mutableStateOf(0)
+        private val onBoardingScreenIndex = mutableStateOf(0)
 
         private fun handleBackAndForwardNavigation(): String {
-            return when (onBoardingScreensIndex.value) {
+            return when (onBoardingScreenIndex.value) {
                 0 -> Cost.route
                 1 -> Unit.route
                 2 -> Date.route
@@ -27,19 +27,16 @@ sealed class Screen(val route: String, var title: String) {
         }
 
         fun onBackPressed(moveToBack: OnBackPressedCallback): String {
-            if (onBoardingScreensIndex.value <= 0) {
-                onBoardingScreensIndex.value = 0 // för att säkerställa att det verkligen aldrig blir mindre än 0
-
+            if (onBoardingScreenIndex.value <= 0) {
+                onBoardingScreenIndex.value = 0 // för att säkerställa att det verkligen aldrig blir mindre än 0
                 moveToBack.handleOnBackPressed()
             }
-
-            onBoardingScreensIndex.value = onBoardingScreensIndex.value - 1
-
+            onBoardingScreenIndex.value = onBoardingScreenIndex.value - 1
             return handleBackAndForwardNavigation()
         }
 
         fun nextScreen(): String {
-            onBoardingScreensIndex.value += 1
+            onBoardingScreenIndex.value += 1
             return handleBackAndForwardNavigation()
         }
 

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
@@ -37,6 +37,7 @@ sealed class Screen(val route: String, var title: String) {
             if (onBoardingScreenIndex.value <= 0) {
                 onBoardingScreenIndex.value = 0 // för att säkerställa att det verkligen aldrig blir mindre än 0
                 moveToBack.handleOnBackPressed()
+                return
             }
             onBoardingScreenIndex.value = onBoardingScreenIndex.value - 1
             handleBackAndForwardNavigation(navController)

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
@@ -1,6 +1,10 @@
 package com.antisnusbolaget.slutasnusa2.navigation
 
-data class BottomBarVisibility(val shouldShowNav: Boolean, val shouldShowYellow: Boolean)
+import androidx.activity.OnBackPressedCallback
+import androidx.compose.runtime.mutableStateOf
+
+data class BottomBarVisibility(val isHomeScreen: Boolean, val isOnBoarding: Boolean)
+
 sealed class Screen(val route: String, var title: String) {
     object Home : Screen(route = "home_screen", title = "Home")
     object Settings : Screen(route = "settings_screen", title = "Settings")
@@ -10,6 +14,35 @@ sealed class Screen(val route: String, var title: String) {
     object Achievement : Screen(route = "achievement_screen", title = "Achievement")
 
     companion object {
+
+        private val onBoardingScreensIndex = mutableStateOf(0)
+
+        private fun handleBackAndForwardNavigation(): String {
+            return when (onBoardingScreensIndex.value) {
+                0 -> Cost.route
+                1 -> Unit.route
+                2 -> Date.route
+                else -> Home.route
+            }
+        }
+
+        fun onBackPressed(moveToBack: OnBackPressedCallback): String {
+            if (onBoardingScreensIndex.value <= 0) {
+                onBoardingScreensIndex.value = 0 // för att säkerställa att det verkligen aldrig blir mindre än 0
+
+                moveToBack.handleOnBackPressed()
+            }
+
+            onBoardingScreensIndex.value = onBoardingScreensIndex.value - 1
+
+            return handleBackAndForwardNavigation()
+        }
+
+        fun nextScreen(): String {
+            onBoardingScreensIndex.value += 1
+            return handleBackAndForwardNavigation()
+        }
+
         private val screensWithTopBar = listOf(
             Cost.route,
             Unit.route,
@@ -33,10 +66,16 @@ sealed class Screen(val route: String, var title: String) {
                 Date.route,
             )
 
-            if (route.isNullOrBlank()) return BottomBarVisibility(shouldShowNav = false, shouldShowYellow = false)
+            if (route.isNullOrBlank()) {
+                return BottomBarVisibility(
+                    isHomeScreen = false,
+                    isOnBoarding = false,
+                )
+            }
 
             val showBottomNav = screensWithBottomNav.any { route.contains(it, ignoreCase = true) }
-            val showBottomYellow = screensWithBottomYellow.any { route.contains(it, ignoreCase = true) }
+            val showBottomYellow =
+                screensWithBottomYellow.any { route.contains(it, ignoreCase = true) }
 
             return BottomBarVisibility(showBottomNav, showBottomYellow)
         }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
@@ -1,8 +1,5 @@
 package com.antisnusbolaget.slutasnusa2.navigation
 
-import androidx.activity.OnBackPressedCallback
-import androidx.compose.runtime.mutableStateOf
-
 data class BottomBarVisibility(val shouldShowNav: Boolean, val shouldShowYellow: Boolean)
 sealed class Screen(val route: String, var title: String) {
     object Home : Screen(route = "home_screen", title = "Home")
@@ -13,8 +10,6 @@ sealed class Screen(val route: String, var title: String) {
     object Achievement : Screen(route = "achievement_screen", title = "Achievement")
 
     companion object {
-        private val onBoardingScreensIndex = mutableStateOf(0)
-
         private val screensWithTopBar = listOf(
             Cost.route,
             Unit.route,
@@ -25,31 +20,6 @@ sealed class Screen(val route: String, var title: String) {
             Home.route,
             Achievement.route,
         )
-        private fun handleBackAndForwardNavigation(): String {
-            return when (onBoardingScreensIndex.value) {
-                0 -> Cost.route
-                1 -> Unit.route
-                2 -> Date.route
-                else -> Home.route // TODO this will point to another NavGraph later
-            }
-        }
-
-        fun onBackPressed(moveToBack: OnBackPressedCallback): String {
-            if (onBoardingScreensIndex.value <= 0) {
-                onBoardingScreensIndex.value = 0 // för att säkerställa att det verkligen aldrig blir mindre än 0
-
-                moveToBack.handleOnBackPressed()
-            }
-
-            onBoardingScreensIndex.value = onBoardingScreensIndex.value - 1
-
-            return handleBackAndForwardNavigation()
-        }
-
-        fun nextScreen(): String {
-            onBoardingScreensIndex.value += 1
-            return handleBackAndForwardNavigation()
-        }
 
         fun shouldShowTopBar(route: String?): Boolean {
             if (route.isNullOrBlank()) return false

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/navigation/Screen.kt
@@ -2,6 +2,7 @@ package com.antisnusbolaget.slutasnusa2.navigation
 
 import androidx.activity.OnBackPressedCallback
 import androidx.compose.runtime.mutableStateOf
+import androidx.navigation.NavController
 
 data class BottomBarVisibility(val isHomeScreen: Boolean, val isOnBoarding: Boolean)
 
@@ -17,27 +18,33 @@ sealed class Screen(val route: String, var title: String) {
 
         private val onBoardingScreenIndex = mutableStateOf(0)
 
-        private fun handleBackAndForwardNavigation(): String {
-            return when (onBoardingScreenIndex.value) {
-                0 -> Cost.route
-                1 -> Unit.route
-                2 -> Date.route
-                else -> Home.route
+        private fun handleBackAndForwardNavigation(navController: NavController) {
+            when (onBoardingScreenIndex.value) {
+                0 -> navController.navigate(Cost.route) // Cost.route
+                1 -> navController.navigate(Unit.route) // Unit.route
+                2 -> navController.navigate(Date.route)
+                else -> {
+                    navController.navigate(Home.route) {
+                        popUpTo(ON_BOARDING_GRAPH_ROUTE) {
+                            inclusive = true
+                        }
+                    }
+                }
             }
         }
 
-        fun onBackPressed(moveToBack: OnBackPressedCallback): String {
+        fun onBackPressed(moveToBack: OnBackPressedCallback, navController: NavController) {
             if (onBoardingScreenIndex.value <= 0) {
                 onBoardingScreenIndex.value = 0 // för att säkerställa att det verkligen aldrig blir mindre än 0
                 moveToBack.handleOnBackPressed()
             }
             onBoardingScreenIndex.value = onBoardingScreenIndex.value - 1
-            return handleBackAndForwardNavigation()
+            handleBackAndForwardNavigation(navController)
         }
 
-        fun nextScreen(): String {
+        fun nextScreen(navController: NavController) {
             onBoardingScreenIndex.value += 1
-            return handleBackAndForwardNavigation()
+            handleBackAndForwardNavigation(navController)
         }
 
         private val screensWithTopBar = listOf(

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/components/BottomNavOnBoarding.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/components/BottomNavOnBoarding.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.antisnusbolaget.slutasnusa2.R
 import com.antisnusbolaget.slutasnusa2.helper.SystemBackPressHandler
 import com.antisnusbolaget.slutasnusa2.navigation.BottomBarVisibility
@@ -32,11 +30,9 @@ import com.antisnusbolaget.slutasnusa2.navigation.BottomNav
 fun BottomNavOnBoarding(
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
-    navController: NavController,
 ) {
     SystemBackPressHandler(
         onBackPressed = {
-            navController.popBackStack()
             onClickBack()
         },
     )
@@ -80,7 +76,6 @@ private fun PreviewComponent() {
     Column() {
         BottomNav(
             bottomBarState = BottomBarVisibility(isOnBoarding = true, isHomeScreen = false),
-            navController = rememberNavController(),
             onClickNext = {},
             onClickBack = {},
         )
@@ -90,7 +85,6 @@ private fun PreviewComponent() {
                 isOnBoarding = false,
                 isHomeScreen = true,
             ),
-            navController = rememberNavController(),
             onClickNext = {},
             onClickBack = {},
         )

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/components/BottomNavOnBoarding.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/components/BottomNavOnBoarding.kt
@@ -29,7 +29,7 @@ import com.antisnusbolaget.slutasnusa2.navigation.BottomBarVisibility
 import com.antisnusbolaget.slutasnusa2.navigation.BottomNav
 
 @Composable
-fun BottomScaffoldYellow(
+fun BottomNavOnBoarding(
     onClickNext: () -> Unit,
     onClickBack: () -> Unit,
     navController: NavController,
@@ -79,7 +79,7 @@ private const val componentName = "BottomBar"
 private fun PreviewComponent() {
     Column() {
         BottomNav(
-            bottomBarState = BottomBarVisibility(shouldShowYellow = true, shouldShowNav = false),
+            bottomBarState = BottomBarVisibility(isOnBoarding = true, isHomeScreen = false),
             navController = rememberNavController(),
             onClickNext = {},
             onClickBack = {},
@@ -87,8 +87,8 @@ private fun PreviewComponent() {
         BottomNav(
             bottomBarState =
             BottomBarVisibility(
-                shouldShowYellow = false,
-                shouldShowNav = true,
+                isOnBoarding = false,
+                isHomeScreen = true,
             ),
             navController = rememberNavController(),
             onClickNext = {},

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/CostScreen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/CostScreen.kt
@@ -2,7 +2,6 @@ package com.antisnusbolaget.slutasnusa2.ui.screens
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -12,18 +11,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import com.antisnusbolaget.slutasnusa2.navigation.Screen
 
 @Composable
-fun CostScreen(navController: NavController) {
+fun CostScreen() {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .clickable {
-                navController.navigate(Screen.Date.route)
-            },
+            .background(MaterialTheme.colorScheme.background),
     ) {
         Text(text = "Cost Screen", fontSize = 30.sp)
     }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/CostScreen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/CostScreen.kt
@@ -2,22 +2,28 @@ package com.antisnusbolaget.slutasnusa2.ui.screens
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.antisnusbolaget.slutasnusa2.navigation.Screen
 
 @Composable
-fun CostScreen() {
+fun CostScreen(navController: NavController) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .clickable {
+                navController.navigate(Screen.Date.route)
+            },
     ) {
         Text(text = "Cost Screen", fontSize = 30.sp)
     }
@@ -31,5 +37,5 @@ private const val componentName = "Cost Screen"
 @Preview("$componentName (large screen)", device = Devices.PIXEL_C)
 @Composable
 private fun PreviewComponent() {
-    CostScreen()
+    // CostScreen()
 }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/DateScreen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/DateScreen.kt
@@ -2,7 +2,6 @@ package com.antisnusbolaget.slutasnusa2.ui.screens
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -10,40 +9,28 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import com.antisnusbolaget.slutasnusa2.navigation.HOME_ROUTE
-import com.antisnusbolaget.slutasnusa2.navigation.ON_BOARDING_GRAPH_ROUTE
 import com.antisnusbolaget.slutasnusa2.ui.components.Calendar
 import com.antisnusbolaget.slutasnusa2.viewmodel.OnBoardingViewModel
 import com.antisnusbolaget.slutasnusa2.viewmodel.`interface`.OnBoardingEvent
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
-fun DateScreen(viewModel: OnBoardingViewModel = koinViewModel(), navController: NavController) {
+fun DateScreen(viewModel: OnBoardingViewModel = koinViewModel()) {
     DateScreenContent(
         onDateSelected = { dateInMillis ->
             viewModel.handleEvents(OnBoardingEvent.SetDate(dateInMillis))
         },
-        navController,
     )
 }
 
 @Composable
 fun DateScreenContent(
     onDateSelected: (Long) -> Unit,
-    navController: NavController,
 ) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .clickable {
-                navController.navigate(HOME_ROUTE) {
-                    popUpTo(ON_BOARDING_GRAPH_ROUTE) {
-                        inclusive = true
-                    }
-                }
-            },
+            .background(MaterialTheme.colorScheme.background),
     ) {
         Calendar(onDateSelected = onDateSelected)
     }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/DateScreen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/DateScreen.kt
@@ -2,6 +2,7 @@ package com.antisnusbolaget.slutasnusa2.ui.screens
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -9,28 +10,40 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import com.antisnusbolaget.slutasnusa2.navigation.HOME_ROUTE
+import com.antisnusbolaget.slutasnusa2.navigation.ON_BOARDING_GRAPH_ROUTE
 import com.antisnusbolaget.slutasnusa2.ui.components.Calendar
 import com.antisnusbolaget.slutasnusa2.viewmodel.OnBoardingViewModel
 import com.antisnusbolaget.slutasnusa2.viewmodel.`interface`.OnBoardingEvent
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
-fun DateScreen(viewModel: OnBoardingViewModel = koinViewModel()) {
+fun DateScreen(viewModel: OnBoardingViewModel = koinViewModel(), navController: NavController) {
     DateScreenContent(
         onDateSelected = { dateInMillis ->
             viewModel.handleEvents(OnBoardingEvent.SetDate(dateInMillis))
         },
+        navController,
     )
 }
 
 @Composable
 fun DateScreenContent(
     onDateSelected: (Long) -> Unit,
+    navController: NavController,
 ) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .clickable {
+                navController.navigate(HOME_ROUTE) {
+                    popUpTo(ON_BOARDING_GRAPH_ROUTE) {
+                        inclusive = true
+                    }
+                }
+            },
     ) {
         Calendar(onDateSelected = onDateSelected)
     }
@@ -44,5 +57,5 @@ private const val componentName = "DateScreen"
 @Preview("$componentName (large screen)", device = Devices.PIXEL_C)
 @Composable
 private fun PreviewComponent() {
-    DateScreen()
+    // DateScreen()
 }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/HomeScreen.kt
@@ -2,6 +2,7 @@ package com.antisnusbolaget.slutasnusa2.ui.screens
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
@@ -12,13 +13,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.antisnusbolaget.slutasnusa2.navigation.Screen
 
 @Composable
-fun HomeScreen() {
+fun HomeScreen(navController: NavController) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Green),
+            .background(Color.Green)
+            .clickable {
+                navController.navigate(Screen.Achievement.route)
+            },
         contentAlignment = Alignment.Center,
     ) {
         Text(text = "Home Screen", fontSize = 30.sp)
@@ -33,5 +39,5 @@ private const val componentName = "Home Screen"
 @Preview("$componentName (large screen)", device = Devices.PIXEL_C)
 @Composable
 private fun PreviewComponent() {
-    HomeScreen()
+    // HomeScreen()
 }

--- a/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/antisnusbolaget/slutasnusa2/ui/screens/HomeScreen.kt
@@ -2,7 +2,6 @@ package com.antisnusbolaget.slutasnusa2.ui.screens
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
@@ -13,18 +12,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import com.antisnusbolaget.slutasnusa2.navigation.Screen
 
 @Composable
-fun HomeScreen(navController: NavController) {
+fun HomeScreen() {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Green)
-            .clickable {
-                navController.navigate(Screen.Achievement.route)
-            },
+            .background(Color.Green),
         contentAlignment = Alignment.Center,
     ) {
         Text(text = "Home Screen", fontSize = 30.sp)


### PR DESCRIPTION
Added separate nav-graphs for onboarding-screens and "when-already-onboarded"-screens. 

All navigation now happens from Screen for onBoardingRoute with direct navController-calls.

Some refactoring of names..
